### PR TITLE
Add new multi-layer structure types and functionality

### DIFF
--- a/include/cwapi3d/CwAPI3DTypes.h
+++ b/include/cwapi3d/CwAPI3DTypes.h
@@ -20,10 +20,10 @@ namespace CwAPI3D
   {
     /// @brief X Coordinate
     double mX;
-    
+
     /// @brief Y Coordinate
     double mY;
-    
+
     /// @brief Z Coordinate
     double mZ;
   };
@@ -32,13 +32,13 @@ namespace CwAPI3D
   /// @brief RGB Color
   struct colorRGB
   {
-    
+
     /// @brief Red Value
     uint32_t mR;
-    
+
     /// @brief Green Value
     uint32_t mG;
-    
+
     /// @brief Blue Value
     uint32_t mB;
   };
@@ -116,7 +116,7 @@ namespace CwAPI3D
     FloorLineDetail,
     FloorOpenDetail
   };
- 
+
   /// @enum shortcutKey
   /// @brief Shortcut key
   enum shortcutKey
@@ -257,13 +257,14 @@ namespace CwAPI3D
     enum multiLayerSubType
     {
       Undefined = 0,
-      FrameStructure = 1,
+      LoadBearingFrameStructure = 1,
       SolidStructure = 2,
       StraightEdge = 3,
       BiasEdge = 4,
       Vertical = 5,
       Horizontal = 6,
       Air = 7,
+      NonLoadBearingFrameStructure = 8,
     };
   }
 
@@ -276,6 +277,22 @@ namespace CwAPI3D
       Undefined = 0,
       Material = 1,
       StandardElement = 2,
+    };
+  }
+
+  namespace multiLayer
+  {
+    enum class multiLayerCoverType : uint8_t
+    {
+      FramedWall = 0,
+      SolidWall = 1,
+      LogWall = 2,
+
+      FramedRoof = 3,
+      SolidRoof = 4,
+
+      FramedFloor = 5,
+      SolidFloor = 6,
     };
   }
 
@@ -327,9 +344,9 @@ namespace CwAPI3D
   /// @brief Shoulder beam geometry
   enum ShoulderBeamGeometry
   {
-    Bisector = 0, ///< Bisector
-    Birdsmouth = 2, ///< PerpBirdmouth
-    PerpendicularToStrut = 3, ///< PerpShoulder
+    Bisector = 0,                   ///< Bisector
+    Birdsmouth = 2,                 ///< PerpBirdmouth
+    PerpendicularToStrut = 3,       ///< PerpShoulder
     PerpendicularToCounterPart = 4, ///< PerpChord
   };
 
@@ -337,7 +354,7 @@ namespace CwAPI3D
   /// @brief Heel shoulder beam geometry
   enum HeelShoulderBeamGeometry
   {
-    Normal = 0, ///< NormalHeel
+    Normal = 0,   ///< NormalHeel
     Straight = 3, ///< StraightHeel
   };
 

--- a/include/cwapi3d/CwAPI3DVersion.h
+++ b/include/cwapi3d/CwAPI3DVersion.h
@@ -16,5 +16,5 @@
 namespace CwAPI3D
 {
   const uint32_t versionMajor = 2025; // PQ: Do not increment this number without consulting me.
-  const uint32_t versionMinor = 309;  // PQ: Let's try matching the build number +1 manually for now.
+  const uint32_t versionMinor = 401;  // PQ: Let's try matching the build number +1 manually for now.
 }

--- a/include/cwapi3d/ICwAPI3DCameraData.h
+++ b/include/cwapi3d/ICwAPI3DCameraData.h
@@ -17,7 +17,6 @@ namespace CwAPI3D
 {
   namespace Interfaces
   {
-    /// @interface ICwAPI3DCameraData
     class ICwAPI3DCameraData
     {
     public:

--- a/include/cwapi3d/ICwAPI3DControllerFactory.h
+++ b/include/cwapi3d/ICwAPI3DControllerFactory.h
@@ -65,7 +65,7 @@ namespace CwAPI3D
   {
     class ICwAPI3DEventSubscriptionController;
 
-    /// @interface ICwAPI3DControllerFactory
+    /// \brief
     class ICwAPI3DControllerFactory
     {
     public:

--- a/include/cwapi3d/ICwAPI3DDimensionController.h
+++ b/include/cwapi3d/ICwAPI3DDimensionController.h
@@ -27,37 +27,12 @@ namespace CwAPI3D
       /// @return [@ref ICwAPI3DString*] A string containing the last error message.
       virtual ICwAPI3DString* getLastError(int32_t* aErrorCode) = 0;
 
-      /// @brief Creates a dimension element to measure distances on 3D parts.
-      /// @details Creates a dimension annotation in 3D space. The dimension is drawn on a plane 
-      /// defined by its normal and offset distance. Points added to the dimension are projected 
-      /// onto this plane, and dimension segments are automatically created between consecutive points.
-      /// @param[in] aXl [@ref vector3D] The direction vector defining the dimension line axis 
-      /// (the direction of the measurement arrow). Can be aligned with X, Y, Z axes or any 3D direction.
-      /// @param[in] aPlaneNormal [@ref vector3D] The normal vector defining the orientation of 
-      /// the dimension plane.
-      /// @param[in] aDistance [@ref vector3D] The offset vector from the dimensioned geometry 
-      /// to where the dimension line is drawn. Can offset in any direction.
-      /// @param[in] aDimensionPoints [@ref ICwAPI3DVertexList*] A list of dimension points to measure. 
-      /// At least 2 points are needed for a valid dimension measurement, but the points can be 
-      /// added later using addSegment(). Points are projected onto the dimension plane.
-      /// @return [@ref elementID] The element ID of the created dimension element.
-      /// @par Example:
-      /// @code{.cpp}
-      /// // Create a list of dimension points
-      /// ICwAPI3DVertexList lListPoints;
-      /// lListPoints.append(vector3D{0, 0, 0});
-      /// lListPoints.append(vector3D{1000, 0, 0});
-      /// lListPoints.append(vector3D{2000, 500, 0});
-      /// lListPoints.append(vector3D{3000, 200, 0});
-      /// lListPoints.append(vector3D{4000, 360, 0});
-      /// lListPoints.append(vector3D{6000, 451, 0});
-      /// // Create the dimension element
-      /// elementID lIdDimension = aFactory.getDimensionController()->createDimension(
-      ///                          vector3D{1, 0, 0}, // xl - dimension arrow direction
-      ///                          vector3D{0, 1, 0}, // plane_normal
-      ///                          vector3D{0, 0, 500}, // distance - offset from geometry
-      ///                          &lListPoints); // dimension_points
-      /// @endcode
+      /// @brief Creates a dimension element.
+      /// @param[in] aXl [@ref vector3D] The x direction of the dimension.
+      /// @param[in] aPlaneNormal [@ref vector3D] The plane normal.
+      /// @param[in] aDistance [@ref vector3D] The distance vector from the anchor point to the dimension reference point.
+      /// @param[in] aDimensionPoints [@ref ICwAPI3DVertexList*] A list of dimension points.
+      /// @return [@ref elementID] The element id of created dimension element.
       virtual elementID createDimension(vector3D aXl, vector3D aPlaneNormal, vector3D aDistance, ICwAPI3DVertexList* aDimensionPoints) = 0;
 
       /// @brief Sets the orientation of a dimension element.
@@ -66,14 +41,9 @@ namespace CwAPI3D
       /// @param[in] aViewDirUp [@ref vector3D] The view direction up vector.
       virtual void setOrientation(ICwAPI3DElementIDList* aElementIdList, vector3D aViewDir, vector3D aViewDirUp) = 0;
 
-
-      /// @brief Adds a point to an existing dimension element.
-      /// @details Adds a new point to the dimension's point list. A dimension segment is automatically 
-      /// created between this point and the previous point. This method can be called multiple times 
-      /// to progressively add more measurement points to the dimension.
-      /// @param[in] aElementId [@ref elementID] The dimension element ID.
-      /// @param[in] aSegment [@ref vector3D] The point to add to the dimension (despite the parameter name, 
-      /// this is a point, not a segment).
+      /// @brief Adds a segment to a dimension element.
+      /// @param[in] aElementId [@ref elementID] The dimension element id.
+      /// @param[in] aSegment [@ref vector3D] The segment to add.
       virtual void addSegment(elementID aElementId, vector3D aSegment) = 0;
 
       /// @brief Sets the precision/decimal places of a dimension element.

--- a/include/cwapi3d/ICwAPI3DDisplayAttribute.h
+++ b/include/cwapi3d/ICwAPI3DDisplayAttribute.h
@@ -4,7 +4,10 @@ namespace CwAPI3D
 {
   namespace Interfaces
   {
-    /// @interface ICwAPI3DDisplayAttribute
+    /**
+    * @interface ICwAPI3DWebGLExportAttribute
+    * \brief
+    */
     class ICwAPI3DDisplayAttribute
     {
     public:

--- a/include/cwapi3d/ICwAPI3DEndtypeIDList.h
+++ b/include/cwapi3d/ICwAPI3DEndtypeIDList.h
@@ -18,7 +18,9 @@ namespace CwAPI3D
 {
   namespace Interfaces
   {
-    /// @interface ICwAPI3DEndtypeIDList
+    /**
+   * \brief EndtypeIDList interface
+   */
     class ICwAPI3DEndtypeIDList
     {
     public:

--- a/include/cwapi3d/ICwAPI3DGeometryController.h
+++ b/include/cwapi3d/ICwAPI3DGeometryController.h
@@ -24,8 +24,8 @@ namespace CwAPI3D
     {
     public:
       /// Gets the last error.
-      /// @param[out] aErrorCode [int32_t*] error code 
-      /// @return [@ref ICwAPI3DString*] error string 
+      /// @param[out] aErrorCode [int32_t*] error code
+      /// @return [@ref ICwAPI3DString*] error string
       virtual ICwAPI3DString* getLastError(int32_t* aErrorCode) = 0;
 
       /// @brief Gets the element width.
@@ -66,7 +66,7 @@ namespace CwAPI3D
       /// @brief Gets the element start width cut angle.
       /// @param[in] aElementId [@ref elementID] The element Id.
       /// @return [double] The element start width cut angle.
-      virtual double getStartWidthCutAngle(elementID aElementId) = 0; 
+      virtual double getStartWidthCutAngle(elementID aElementId) = 0;
 
       /// @brief Gets the element end height cut angle.
       /// @param[in] aElementId [@ref elementID] The element Id.
@@ -425,7 +425,7 @@ namespace CwAPI3D
       /// @return [double] The real weight of the element.
       virtual double getWeightReal(elementID aElementId) = 0;
 
-      /// @brief Gets actual physical volume (includes negative geometry operations, such as end-types, drillings, connectors, openings, and MEP elements) 
+      /// @brief Gets actual physical volume (includes negative geometry operations, such as end-types, drillings, connectors, openings, and MEP elements)
       ///       (it might also take into account different drilling bodies and counterbores in a connector).
       /// @param[in] aElementId [@ref elementID] The element id.
       /// @return [double] The actual physical volume.
@@ -526,6 +526,11 @@ namespace CwAPI3D
       /// @param[in] aStandardElementName [const @ref character*] The standard element name.
       /// @return [double] The standard element length.
       virtual double getStandardElementLengthFromName(const character* aStandardElementName) = 0;
+
+      /// @brief Gets the length of an element including end-types.
+      /// @param[in] aElementId [@ref elementID] The element id.
+      /// @return [double] The element length including end-types.
+      virtual double getLengthIncludingEndTypes(elementID aElementId) = 0;
     };
   }
 }

--- a/include/cwapi3d/ICwAPI3DGridController.h
+++ b/include/cwapi3d/ICwAPI3DGridController.h
@@ -16,7 +16,7 @@ namespace CwAPI3D
 {
   namespace Interfaces
   {
-    /// @interface ICwAPI3DGridController
+    /// \brief 
     class ICwAPI3DGridController
     {
     public:

--- a/include/cwapi3d/ICwAPI3DIfcOptions.h
+++ b/include/cwapi3d/ICwAPI3DIfcOptions.h
@@ -39,7 +39,6 @@ namespace CwAPI3D
       virtual ICwAPI3DIfcOptionsAggregation* getCwAPI3DIfcOptionsAggregation() = 0;
     };
 
-    /// @interface ICwAPI3DIfcOptionsProjectData
     class ICwAPI3DIfcOptionsProjectData
     {
     public:
@@ -61,7 +60,6 @@ namespace CwAPI3D
       virtual void setExportTrueNorthInObjectPlacement(bool aValue) = 0;
     };
 
-    /// @interface ICwAPI3DIfcOptionsProperties
     class ICwAPI3DIfcOptionsProperties
     {
     public:
@@ -89,7 +87,6 @@ namespace CwAPI3D
       virtual void setExportQuantitySets(bool aValue) = 0;
     };
 
-    /// @interface ICwAPI3DIfcOptionsLevelOfDetail
     class ICwAPI3DIfcOptionsLevelOfDetail
     {
     public:
@@ -126,7 +123,6 @@ namespace CwAPI3D
       virtual void setExportSweptSolidForSimpleGeometry(bool aValue) = 0;
     };
 
-    /// @interface ICwAPI3DIfcOptionsAggregation
     class ICwAPI3DIfcOptionsAggregation
     {
     public:

--- a/include/cwapi3d/ICwAPI3DImport3dcOptions.h
+++ b/include/cwapi3d/ICwAPI3DImport3dcOptions.h
@@ -16,7 +16,6 @@ namespace CwAPI3D
 {
   namespace Interfaces
   {
-    /// @interface ICwAPI3DImport3dcOptions
     class ICwAPI3DImport3dcOptions
     {
     public:

--- a/include/cwapi3d/ICwAPI3DMultiLayerCoverController.h
+++ b/include/cwapi3d/ICwAPI3DMultiLayerCoverController.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "ICwAPI3DList.h"
 #include "ICwAPI3DString.h"
 
 #include <vector>
@@ -24,6 +25,7 @@ namespace CwAPI3D
     public:
       /// @brief Gets all multi layer wall ids.
       /// @return [std::vector<@ref multiLayerSetID>] The multi layer wall ids.
+      /// @attention This function is not ABI stable. Use getMultiLayerWallsEx() for ABI stable code.
       /// @par Example:
       /// @code{.cpp}
       ///     std::vector<multiLayerSetID> wallIds = aFactory->getMultiLayerCoverController()->getMultiLayerWalls();
@@ -405,6 +407,225 @@ namespace CwAPI3D
       /// @param[in] aBeamGuid [@ref character*] The layer standard beam guid.
       /// @param[in] aThickness [double] The layer thickness.
       virtual void addLayerByStandardElements(multiLayerSetID aSetId, multiLayerType aType, const character* aName, const character* aPanelGuid, const character* aBeamGuid, double aThickness) = 0;
+
+      /// @brief Gets all framed multi layer floor ids.
+      /// @return [std::vector<@ref multiLayerSetID>] The multi layer floor ids.
+      /// @par Example:
+      /// @code{.cpp}
+      ///     std::vector<multiLayerSetID> floorIds = aFactory->getMultiLayerCoverController()->getMultiLayerFramedFloors();
+      ///     printf("Found %d multi-layer floor definitions\n", floorIds.size());
+      ///
+      ///     for (size_t i = 0; i < floorIds.size(); ++i)
+      ///     {
+      ///         multiLayerSetID floorId = floorIds[i];
+      ///         ICwAPI3DString* name = aFactory->getMultiLayerCoverController()->getMultiLayerSetName(floorId);
+      ///         wprintf(L"Floor ID: %d, Name: %ls\n", floorId, name->data());
+      ///     }
+      /// @endcode
+      virtual ICwAPI3DMultiLayerSetIDList* getMultiLayerFramedFloors() = 0;
+
+      /// @brief Creates a new multi layer floor with given name and default values.
+      /// @param[in] aSetName  [const @ref character*] The multi layer set name.
+      /// @return [@ref multiLayerSetID] The multi layer set id.
+      /// @par Example:
+      /// @code{.cpp}
+      ///     multiLayerSetID multiLayerSetId = aFactory->getMultiLayerCoverController()->createMultiLayerFramedFloor("Standard Floor");
+      ///     printf("Created new multi-layer floor with ID: %d\n", multiLayerSetId);
+      /// @endcode
+      virtual multiLayerSetID createMultiLayerFramedFloor(const character* aSetName) = 0;
+
+      /// @brief Gets all multi layer roof ids.
+      /// @return [std::vector<@ref multiLayerSetID>] The multi layer roof ids.
+      /// @par Example:
+      /// @code{.cpp}
+      ///     std::vector<multiLayerSetID> roofIds = aFactory->getMultiLayerCoverController()->getMultiLayerFramedRoofs();
+      ///     printf("Found %d multi-layer roof definitions\n", roofIds.size());
+      ///
+      ///     for (size_t i = 0; i < roofIds.size(); ++i)
+      ///     {
+      ///         multiLayerSetID roofId = roofIds[i];
+      ///         ICwAPI3DString* name = aFactory->getMultiLayerCoverController()->getMultiLayerSetName(roofId);
+      ///         wprintf(L"Roof ID: %d, Name: %ls\n", roofId, name->data());
+      ///     }
+      /// @endcode
+      virtual ICwAPI3DMultiLayerSetIDList* getMultiLayerFramedRoofs() = 0;
+
+      /// @brief Gets all solid multi layer floor ids.
+      /// @return [std::vector<@ref multiLayerSetID>] The multi layer floor ids.
+      /// @par Example:
+      /// @code{.cpp}
+      ///     std::vector<multiLayerSetID> floorIds = aFactory->getMultiLayerCoverController()->getMultiLayerSolidFloors();
+      ///     printf("Found %d multi-layer floor definitions\n", floorIds.size());
+      ///
+      ///     for (size_t i = 0; i < floorIds.size(); ++i)
+      ///     {
+      ///         multiLayerSetID floorId = floorIds[i];
+      ///         ICwAPI3DString* name = aFactory->getMultiLayerCoverController()->getMultiLayerSetName(floorId);
+      ///         wprintf(L"Floor ID: %d, Name: %ls\n", floorId, name->data());
+      ///     }
+      /// @endcode
+      virtual ICwAPI3DMultiLayerSetIDList* getMultiLayerSolidFloors() = 0;
+
+      /// @brief Creates a new multi layer solid floor with given name and default values.
+      /// @param[in] aSetName  [const @ref character*] The multi layer set name.
+      /// @return [@ref multiLayerSetID] The multi layer set id.
+      /// @par Example:
+      /// @code{.cpp}
+      ///     multiLayerSetID multiLayerSetId = aFactory->getMultiLayerCoverController()->createMultiLayerSolidFloor("Standard Solid Floor");
+      ///     printf("Created new multi-layer solid floor with ID: %d\n", multiLayerSetId);
+      /// @endcode
+      virtual multiLayerSetID createMultiLayerSolidFloor(const character* aSetName) = 0;
+
+
+      /// @brief Creates a new multi layer roof with given name and default values.
+      /// @param[in] aSetName  [const @ref character*] The multi layer set name.
+      /// @return [@ref multiLayerSetID] The multi layer set id.
+      /// @par Example:
+      /// @code{.cpp}
+      ///     multiLayerSetID multiLayerSetId = aFactory->getMultiLayerCoverController()->createMultiLayerFramedRoof("Pitched Roof");
+      ///     printf("Created new multi-layer roof with ID: %d\n", multiLayerSetId);
+      /// @endcode
+      virtual multiLayerSetID createMultiLayerFramedRoof(const character* aSetName) = 0;
+
+      /// @brief Creates a new multi layer wall with given name and default values.
+      /// @param[in] aSetName  [const @ref character*] The multi layer set name.
+      /// @return [@ref multiLayerSetID] The multi layer set id.
+      /// @par Example:
+      /// @code{.cpp}
+      ///     multiLayerSetID multiLayerSetId = aFactory->getMultiLayerCoverController()->createMultiLayerFramedWall("Standard Wall");
+      ///     printf("Created new multi-layer wall with ID: %d\n", multiLayerSetId);
+      /// @endcode
+      virtual multiLayerSetID createMultiLayerFramedWall(const character* aSetName) = 0;
+
+      /// @brief Gets all multi layer set ids of all types.
+      /// @return [std::vector<@ref multiLayerSetID>] All multi layer set ids.
+      /// @par Example:
+      /// @code{.cpp}
+      ///     std::vector<multiLayerSetID> allIds = aFactory->getMultiLayerCoverController()->getAllMultiLayerTypes();
+      ///     printf("Found %d multi-layer definitions in total\n", allIds.size());
+      ///
+      ///     for (size_t i = 0; i < allIds.size(); ++i)
+      ///     {
+      ///         multiLayerSetID setId = allIds[i];
+      ///         ICwAPI3DString* name = aFactory->getMultiLayerCoverController()->getMultiLayerSetName(setId);
+      ///         wprintf(L"Set ID: %d, Name: %ls\n", setId, name->data());
+      ///     }
+      /// @endcode
+      virtual ICwAPI3DMultiLayerSetIDList* getMultiLayerSets() = 0;
+
+      /// @brief Creates a new multi layer set of specified type with given name and default values.
+      /// @param[in] aSetName  [const @ref character*] The multi layer set name.
+      /// @param[in] aCoverType [@ref multiLayerCoverType::multiLayerCoverType] The cover type.
+      /// @return [@ref multiLayerSetID] The multi layer set id.
+      /// @par Example:
+      /// @code{.cpp}
+      ///     multiLayerSetID multiLayerSetId = aFactory->getMultiLayerCoverController()->createMultiLayerByCoverType("Custom Solid Wall", multiLayerCoverType::multiLayerCoverType::SolidWall);
+      ///     printf("Created new multi-layer set with ID: %d\n", multiLayerSetId);
+      /// @endcode
+      virtual multiLayerSetID createMultiLayerByCoverType(const character* aSetName, multiLayer::multiLayerCoverType aCoverType) = 0;
+
+      /// @brief Gets all multi layer set ids of specified cover type.
+      /// @param[in] aCoverType [@ref multiLayerCoverType::multiLayerCoverType] The cover type.
+      /// @return  [ICwAPI3DMultiLayerSetIDList*] The multi layer set ids.
+      /// @par Example:
+      /// @code{.cpp}
+      ///       ICwAPI3DMultiLayerSetIDList* setIds = aFactory->getMultiLayerCoverController()->getMultiLayerSetsForCoverType(multiLayerCoverType::multiLayerCoverType::SolidWall);
+      /// @endcode
+      virtual ICwAPI3DMultiLayerSetIDList* getMultiLayerSetsForCoverType(multiLayer::multiLayerCoverType aCoverType) = 0;
+
+      /// @brief Gets all multi layer wall ids.
+      /// @return [ICwAPI3DMultiLayerSetIDList*] The multi layer wall ids.
+      /// @par Example:
+      /// @code{.cpp}
+      ///     ICwAPI3DMultiLayerSetIDList* wallIds = aFactory->getMultiLayerCoverController()->getMultiLayerWallsEx();
+      ///     printf("Found %d multi-layer wall definitions\n", wallIds->count());
+      ///
+      ///     for (size_t i = 0; i < wallIds->count(); ++i)
+      ///     {
+      ///         multiLayerSetID wallId = wallIds->at(i);
+      ///         ICwAPI3DString* name = aFactory->getMultiLayerCoverController()->getMultiLayerSetName(wallId);
+      ///         wprintf(L"Wall ID: %d, Name: %ls\n", wallId, name->data());
+      ///     }
+      /// @endcode
+      virtual ICwAPI3DMultiLayerSetIDList* getMultiLayerWallsEx() = 0;
+
+      /// @brief Gets all multi layer log wall ids.
+      /// @return [ICwAPI3DMultiLayerSetIDList*] The multi layer log wall ids.
+      /// @par Example:
+      /// @code{.cpp}
+      ///     ICwAPI3DMultiLayerSetIDList* logWallIds = aFactory->getMultiLayerCoverController()->getMultiLayerLogWalls();
+      ///     printf("Found %d multi-layer log wall definitions\n", logWallIds->count());
+      ///
+      ///     for (size_t i = 0; i < logWallIds->count(); ++i)
+      ///     {
+      ///         multiLayerSetID logWallId = logWallIds->at(i);
+      ///         ICwAPI3DString* name = aFactory->getMultiLayerCoverController()->getMultiLayerSetName(logWallId);
+      ///         wprintf(L"Log Wall ID: %d, Name: %ls\n", logWallId, name->data());
+      ///     }
+      /// @endcode
+      virtual ICwAPI3DMultiLayerSetIDList* getMultiLayerLogWalls() = 0;
+
+      /// @brief Creates a new multi layer log wall with given name and default values.
+      /// @param[in] aSetName  [const @ref character*] The multi layer set name.
+      /// @return [@ref multiLayerSetID] The multi layer set id.
+      /// @par Example:
+      /// @code{.cpp}
+      ///     multiLayerSetID multiLayerSetId = aFactory->getMultiLayerCoverController()->createMultiLayerLogWall("Standard Log Wall");
+      ///     printf("Created new multi-layer log wall with ID: %d\n", multiLayerSetId);
+      /// @endcode
+      virtual multiLayerSetID createMultiLayerLogWall(const character* aSetName) = 0;
+
+      /// @brief Gets all multi layer solid roof ids.
+      /// @return [ICwAPI3DMultiLayerSetIDList*] The multi layer solid roof ids.
+      /// @par Example:
+      /// @code{.cpp}
+      ///     ICwAPI3DMultiLayerSetIDList* solidRoofIds = aFactory->getMultiLayerCoverController()->getMultiLayerSolidRoofs();
+      ///     printf("Found %d multi-layer solid roof definitions\n", solidRoofIds->count());
+      ///
+      ///     for (size_t i = 0; i < solidRoofIds->count(); ++i)
+      ///     {
+      ///         multiLayerSetID solidRoofId = solidRoofIds->at(i);
+      ///         ICwAPI3DString* name = aFactory->getMultiLayerCoverController()->getMultiLayerSetName(solidRoofId);
+      ///         wprintf(L"Solid Roof ID: %d, Name: %ls\n", solidRoofId, name->data());
+      ///     }
+      /// @endcode
+      virtual ICwAPI3DMultiLayerSetIDList* getMultiLayerSolidRoofs() = 0;
+
+      /// @brief Creates a new multi layer solid roof with given name and default values.
+      /// @param[in] aSetName  [const @ref character*] The multi layer set name.
+      /// @return [@ref multiLayerSetID] The multi layer set id.
+      /// @par Example:
+      /// @code{.cpp}
+      ///     multiLayerSetID multiLayerSetId = aFactory->getMultiLayerCoverController()->createMultiLayerSolidRoof("Standard Solid Roof");
+      ///     printf("Created new multi-layer solid roof with ID: %d\n", multiLayerSetId);
+      /// @endcode
+      virtual multiLayerSetID createMultiLayerSolidRoof(const character* aSetName) = 0;
+
+      /// @brief Gets all multi layer solid wall ids.
+      /// @return [ICwAPI3DMultiLayerSetIDList*] The multi layer solid wall ids.
+      /// @par Example:
+      /// @code{.cpp}
+      ///     ICwAPI3DMultiLayerSetIDList* solidWallIds = aFactory->getMultiLayerCoverController()->getMultiLayerSolidWalls();
+      ///     printf("Found %d multi-layer solid wall definitions\n", solidWallIds->count());
+      ///
+      ///     for (size_t i = 0; i < solidWallIds->count(); ++i)
+      ///     {
+      ///         multiLayerSetID solidWallId = solidWallIds->at(i);
+      ///         ICwAPI3DString* name = aFactory->getMultiLayerCoverController()->getMultiLayerSetName(solidWallId);
+      ///         wprintf(L"Solid Wall ID: %d, Name: %ls\n", solidWallId, name->data());
+      ///     }
+      /// @endcode
+      virtual ICwAPI3DMultiLayerSetIDList* getMultiLayerSolidWalls() = 0;
+
+      /// @brief Creates a new multi layer solid wall with given name and default values.
+      /// @param[in] aSetName  [const @ref character*] The multi layer set name.
+      /// @return [@ref multiLayerSetID] The multi layer set id.
+      /// @par Example:
+      /// @code{.cpp}
+      ///     multiLayerSetID multiLayerSetId = aFactory->getMultiLayerCoverController()->createMultiLayerSolidWall("Standard Solid Wall");
+      ///     printf("Created new multi-layer solid wall with ID: %d\n", multiLayerSetId);
+      /// @endcode
+      virtual multiLayerSetID createMultiLayerSolidWall(const character* aSetName) = 0;
     };
   }
 }

--- a/include/cwapi3d/ICwAPI3DRhinoOptions.h
+++ b/include/cwapi3d/ICwAPI3DRhinoOptions.h
@@ -16,7 +16,6 @@ namespace CwAPI3D
 {
   namespace Interfaces
   {
-    /// @interface ICwAPI3DRhinoOptions
     class ICwAPI3DRhinoOptions
     {
     public:

--- a/include/cwapi3d/ICwAPI3DShoulderOptions.h
+++ b/include/cwapi3d/ICwAPI3DShoulderOptions.h
@@ -17,7 +17,6 @@ namespace CwAPI3D
 {
   namespace Interfaces
   {
-    /// @interface ICwAPI3DShoulderOptions
     class ICwAPI3DShoulderOptions
     {
     public:
@@ -76,7 +75,6 @@ namespace CwAPI3D
       virtual void setEndTypeNameQueryUserFlag(bool aFlag) = 0;
     };
 
-    /// @interface ICwAPI3DHeelShoulderOptions
     class ICwAPI3DHeelShoulderOptions
     {
     public:
@@ -115,7 +113,6 @@ namespace CwAPI3D
       virtual void setEndTypeNameQueryUserFlag(bool aFlag) = 0;
     };
 
-    /// @interface ICwAPI3DDoubleShoulderOptions
     class ICwAPI3DDoubleShoulderOptions
     {
     public:

--- a/include/cwapi3d/ICwAPI3DTextObjectOptions.h
+++ b/include/cwapi3d/ICwAPI3DTextObjectOptions.h
@@ -17,7 +17,6 @@ namespace CwAPI3D
 {
   namespace Interfaces
   {
-    /// @interface ICwAPI3DTextObjectOptions
     class ICwAPI3DTextObjectOptions
     {
     public:


### PR DESCRIPTION
- Add new multi-layer structure types and functionality to `ICwAPI3DMultiLayerCoverController` (e.g., utility functions for framed/single-layer walls, roofs, and floors).
- Introduce `multiLayerCoverType` and extend `multiLayerSubType` enumerations.